### PR TITLE
CreationService - Issues #45 #46 #47

### DIFF
--- a/CreationService/.gitignore
+++ b/CreationService/.gitignore
@@ -1,0 +1,6 @@
+
+.DS_Store
+.vscode/
+[Bb]in/
+[Oo]bj/
+publish/

--- a/CreationService/CommandRouter.cs
+++ b/CreationService/CommandRouter.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading.Tasks;
+using CreationService.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace CreationService
+{
+    internal static class CommandRouter
+    {
+        internal static async Task RouteAsync(string message)
+        {
+            JObject receivedObj = JsonConvert.DeserializeObject<JObject>(message);
+            string command = receivedObj["command"].Value<string>();
+            int eventId = receivedObj["EventId"].Value<int>();
+            string correlationId = receivedObj["correlationId"].Value<string>();
+            string replyTo = receivedObj["replyTo"].Value<string>();
+
+            switch (command)
+            {
+                case "add":
+                    string location = receivedObj["Location"].Value<string>();
+                    string driveFrom = receivedObj["DriveFrom"].Value<string>();
+                    DateTime dateFrom = receivedObj["DateFrom"].Value<DateTime>();
+                    DateTime dateTo = receivedObj["DateTo"].Value<DateTime>();
+
+                    Event rating = new Event()
+                    {
+                        EventId = eventId,
+                        Location = location,
+                        DriveFrom = driveFrom,
+                        DateFrom  = dateFrom,
+                        DateTo = dateTo
+                    };
+
+                    MessageGateway.PublishRPC()
+                    break;
+                case "get":
+                    await AppDb.Instance.Connection.OpenAsync();
+                    RatingQuery query = new RatingQuery(AppDb.Instance);
+                    Rating foundRating = await query.FindOneAsync(eventId);
+
+                    if(!(foundRating is null))
+                        // Convert to JSON without a command
+                        MessageGateway.PublishRPC(replyTo, correlationId, foundRating.ConvertToJson(""));
+                    break;
+                default:
+                    Console.WriteLine("No such command");
+                    break;
+            }
+        }
+    }
+}

--- a/CreationService/CommandRouter.cs
+++ b/CreationService/CommandRouter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using CreationService.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/CreationService/CreationService.csproj
+++ b/CreationService/CreationService.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="RabbitMq.Client" Version="5.1.2" />
+  </ItemGroup>
+
+</Project>

--- a/CreationService/Dockerfile
+++ b/CreationService/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app
 
 COPY ./publish .
 
-ENTRYPOINT ["dotnet", "RatingService.dll"]
+ENTRYPOINT ["dotnet", "CreationService.dll"]

--- a/CreationService/Dockerfile
+++ b/CreationService/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0
+
+WORKDIR /app
+
+COPY ./publish .
+
+ENTRYPOINT ["dotnet", "RatingService.dll"]

--- a/CreationService/MessageGateway.cs
+++ b/CreationService/MessageGateway.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace CreationService
+{
+    public static class MessageGateway
+    {
+        private static ConnectionFactory factory;
+        private static IConnection connection;
+        private static IModel channel;
+        static MessageGateway()
+        {
+            factory = new ConnectionFactory() { HostName = "rabbitmq" };
+            connection = factory.CreateConnection();
+            channel = connection.CreateModel();
+        }
+
+        internal static void ReceiveEvent()
+        {
+            channel.QueueDeclare(queue: "event.add",
+                                 durable: false,
+                                 exclusive: false,
+                                 autoDelete: false,
+                                 arguments: null);
+
+            var consumer = new EventingBasicConsumer(channel);
+            consumer.Received += async (model, ea) =>
+            {
+                var body = ea.Body;
+                var message = Encoding.UTF8.GetString(body);
+                Console.WriteLine(" [x] Received {0}", message);
+
+                JObject msgObj = JsonConvert.DeserializeObject<JObject>(message);
+                msgObj["correlationId"] = ea.BasicProperties.CorrelationId;
+                msgObj["replyTo"] = ea.BasicProperties.ReplyTo;
+
+                await CommandRouter.RouteAsync(msgObj.ToString());
+
+            };
+            channel.BasicConsume(queue: "event.feedback",
+                                 autoAck: true,
+                                 consumer: consumer);
+        }
+
+        internal static void PublishRPC(string replyTo, string correlationId, string rating)
+        {
+            var responseBytes = Encoding.UTF8.GetBytes(rating);
+            var replyProps = channel.CreateBasicProperties();
+            replyProps.CorrelationId = correlationId;
+
+            channel.BasicPublish(
+                exchange: "", 
+                routingKey: replyTo, 
+                basicProperties: replyProps,
+                body: responseBytes);
+            
+            Console.WriteLine("Published to {0}", replyTo);
+        }
+    }
+}

--- a/CreationService/MessageGateway.cs
+++ b/CreationService/MessageGateway.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Text;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 

--- a/CreationService/MessageGateway.cs
+++ b/CreationService/MessageGateway.cs
@@ -14,7 +14,7 @@ namespace CreationService
         private static IModel channel;
         static MessageGateway()
         {
-            factory = new ConnectionFactory() { HostName = "localhost" };
+            factory = new ConnectionFactory() { HostName = "rabbitmq" };
             connection = factory.CreateConnection();
             channel = connection.CreateModel();
         }

--- a/CreationService/Models/Event.cs
+++ b/CreationService/Models/Event.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Data;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace CreationService.Models
+{
+    public class Event : IJSONConvertable
+    {
+        public int EventId { get; set; }
+        public string Location { get; set; }
+        public string DriverName { get; set; }
+        public string DriveFrom { get; set; }
+        public DateTime DateFrom { get; set; }
+        public DateTime DateTo { get; set; }
+        public int NumberOfPeople { get; set; }
+        public EventType EventType { get; set; }
+        public string ResponsibleName { get; set; }
+        public string ResponsiblePhoneNr { get; set; }
+        public string Notes { get; set; }
+
+        public string ConvertToJson(string command)
+        {
+            JObject eventObj = JObject.FromObject(this);
+            eventObj["command"] = command;
+
+            return eventObj.ToString();
+        }
+    }
+
+
+}

--- a/CreationService/Models/Event.cs
+++ b/CreationService/Models/Event.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Data;
-using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
 namespace CreationService.Models

--- a/CreationService/Models/EventRequest.cs
+++ b/CreationService/Models/EventRequest.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace CreationService.Models
+{
+    public class EventRequest
+    {
+        public Guid RequestId {get;set;}
+        public Event Event {get;set;}
+
+        public EventRequest(Guid requestId, Event @event)
+        {
+            RequestId = requestId;
+            Event = @event;
+        }
+    }
+}

--- a/CreationService/Models/EventRequestRepository.cs
+++ b/CreationService/Models/EventRequestRepository.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace CreationService.Models
+{
+    public class EventRequestRepository
+    {
+        Dictionary<Guid, EventRequest> requests;
+
+        private static EventRequestRepository _instance;
+
+        public static EventRequestRepository Instance
+        {
+            get
+            {
+                if (_instance is null)
+                    _instance = new EventRequestRepository();
+
+                return _instance;
+            }
+        }
+
+        private EventRequestRepository()
+        {
+            requests = new Dictionary<Guid, EventRequest>();
+        }
+
+        public void AddRequest(EventRequest r)
+        {
+            if (requests.ContainsKey(r.RequestId))
+                return;
+
+            requests.Add(r.RequestId, r);
+        }
+
+        public EventRequest GetRequest(Guid id)
+        {
+            return requests.ContainsKey(id) ? requests[id] : null; 
+        }
+    }
+}

--- a/CreationService/Models/EventType.cs
+++ b/CreationService/Models/EventType.cs
@@ -1,0 +1,8 @@
+namespace CreationService.Models
+{
+    public class EventType
+    {
+        public int EventTypeId { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/CreationService/Models/IJSONConvertable.cs
+++ b/CreationService/Models/IJSONConvertable.cs
@@ -1,0 +1,7 @@
+namespace CreationService.Models
+{
+    public interface IJSONConvertable
+    {
+        public string ConvertToJson(string command);
+    }
+}

--- a/CreationService/Program.cs
+++ b/CreationService/Program.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RabbitMQ.Client.Events;
 
 namespace CreationService
 {
@@ -6,9 +10,26 @@ namespace CreationService
     {
         static void Main(string[] args)
         {
-            MessageGateway.ReceiveEvent();
+            new Program().Run();
+        }
+
+        private void Run()
+        {
+            MessageGateway.ReceiveQueue("event.add", ReceivedEvent);
+            MessageGateway.ReceiveQueue("cars.available", ReceivedEvent);
+            MessageGateway.ReceiveQueue("driver.found", ReceivedEvent);
+
             Console.WriteLine("Running");
             while (true) { }
+        }
+
+        void ReceivedEvent(object sender, BasicDeliverEventArgs ea)
+        {
+            var body = ea.Body;
+            var message = Encoding.UTF8.GetString(body);
+            Console.WriteLine(" [x] Received {0}", message);
+
+            CommandRouter.Route(message);
         }
     }
 }

--- a/CreationService/Program.cs
+++ b/CreationService/Program.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Text;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using RabbitMQ.Client.Events;
 
 namespace CreationService

--- a/CreationService/Program.cs
+++ b/CreationService/Program.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace CreationService
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            MessageGateway.ReceiveEvent();
+            Console.WriteLine("Running");
+            while (true) { }
+        }
+    }
+}


### PR DESCRIPTION
## Checklist
- [x] Implement an "events" queue which would subscribe to messages which have the "events.add"
- [x] Create a request to the Connector for available cars using the "connector.requests" queue with a "getAvailableCars" command
- [x] Send a message to the "driver.find" queue with enough data for it to find suitable drivers

### PR Description
Created a new .Net Core console application.
Added functionality to subscribe to **event.add**, **cars.available** and **driver.found** queues.
Added functionality to publish to **connector.requests** and **driver.find** queues, on each message to these we send a "RequestId" which we use to correlate to an event using the _EventRequestRepository_.

### How to test
I have created a docker image of the creation service and it is pushed to docker hub

Start by executing the following docker commands:
- `docker network create testnet`

- `docker run --rm --name rabbitmq -d --network=testnet -p 15672:15672 -p 5672:5672 rabbitmq:management`
- `docker run --rm --name creationservice --network=testnet davi7816/testcreationservice`
(before succeeding to start the service, you should give some time to rabbitmq to start)

After all of these are started, you can test the functionality by heading to the rabbit MQ web interface at [http://localhost:15672/](http://localhost:15672/). In there head over to queues.

> Sending the request for a new event  

Publish the following message into the **event.add** queue.
`{ "command":"add", "EventId":"1", "Location":"Porto", "DriveFrom":"Lisbon", "DateFrom":"2015-06-23", "DateTo":"2015-06-25" } `
This will start the process of finding a car and a driver. You can verify this by publishing the next commands.

> Getting the needed RequestId identifier

You can get the needed identifier by heading to the following queues: **connector.requests** and **driver.find**, and getting a message. Each of this identifiers will be needed for the next messages.

> Responding with found cars  

Publish the following message into the **cars.available** queue. Dont forget to replace the _requestId_ with the one you obtained for the **connector.requests** queue in the previous step.
`{ "command":"carFound", "requestId":"6bb1e582-9592-44d7-9e0f-d82a7f737ce7", "cars": [{ "license":"123456789", "type":"A", "seats":4, "price":125 }] }  `

> Responding with found drivers

Publish the following message into the **driver.found** queue. Dont forget to replace the _requestId_ with the one you obtained for the **driver.find** queue in the previous step.
`{ "command":"driverFound", "requestId":"4c51322a-7d3d-456a-b093-31271511f3ff", "drivers": [{ "Name":"David" }] }  `

> Testing if everything went fine
If everything went fine you should now have a queue named **event.update**. Head over to this queue and get 2 messages, you should be able to get both of them, one with a "car" command and another with a "driver" command.



Issue reference

close #45 
close #46
close #47 