### PR TITLE
Issues #53 #54 #55 #56

### DIFF
--- a/LoggerService/.gitignore
+++ b/LoggerService/.gitignore
@@ -1,0 +1,6 @@
+
+.DS_Store
+.vscode/
+[Bb]in/
+[Oo]bj/
+publish/

--- a/LoggerService/CommandRouter.cs
+++ b/LoggerService/CommandRouter.cs
@@ -29,6 +29,7 @@ namespace LoggerService
                 case "critical":
                     log.Level = LogLevel.CRITICAL;
                     break;
+                    
                 default:
                     Console.WriteLine("No such route");
                     break;

--- a/LoggerService/CommandRouter.cs
+++ b/LoggerService/CommandRouter.cs
@@ -1,4 +1,5 @@
 using System;
+using LoggerService.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -9,24 +10,31 @@ namespace LoggerService
         internal static void Route(string routingKey, string message)
         {
             JObject receivedObj = JsonConvert.DeserializeObject<JObject>(message);
+            string logMessage = receivedObj["message"].Value<string>();
+            string logService = receivedObj["service"].Value<string>();
+            Log log = new Log();
+            log.Message = logMessage;
+            log.Service = logService;
 
             switch (routingKey)
             {
                 case "info":
-                   
+                    log.Level = LogLevel.INFO;
                     break;
 
                 case "warning":
-                    
+                    log.Level = LogLevel.WARNING;
                     break;
 
                 case "critical":
-                   
+                    log.Level = LogLevel.CRITICAL;
                     break;
                 default:
                     Console.WriteLine("No such route");
                     break;
             }
+
+            LogProcessor.Process(log);
         }
     }
 }

--- a/LoggerService/CommandRouter.cs
+++ b/LoggerService/CommandRouter.cs
@@ -1,0 +1,32 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace LoggerService
+{
+    public class CommandRouter
+    {
+        internal static void Route(string routingKey, string message)
+        {
+            JObject receivedObj = JsonConvert.DeserializeObject<JObject>(message);
+
+            switch (routingKey)
+            {
+                case "info":
+                   
+                    break;
+
+                case "warning":
+                    
+                    break;
+
+                case "critical":
+                   
+                    break;
+                default:
+                    Console.WriteLine("No such route");
+                    break;
+            }
+        }
+    }
+}

--- a/LoggerService/Dockerfile
+++ b/LoggerService/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0
+
+WORKDIR /app
+
+COPY ./publish .
+
+ENTRYPOINT ["dotnet", "CreationService.dll"]

--- a/LoggerService/Dockerfile
+++ b/LoggerService/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app
 
 COPY ./publish .
 
-ENTRYPOINT ["dotnet", "CreationService.dll"]
+ENTRYPOINT ["dotnet", "LoggerService.dll"]

--- a/LoggerService/LogProcessor.cs
+++ b/LoggerService/LogProcessor.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using LoggerService.Model;
+
+namespace LoggerService
+{
+    public static class LogProcessor
+    {
+        private static StreamWriter writer;
+
+        static LogProcessor()
+        {
+            writer = new StreamWriter(AppDomain.CurrentDomain.BaseDirectory + "log.txt", true);
+        }
+
+
+        public static void Process(Log log)
+        {
+            if (log.Level == LogLevel.CRITICAL)
+                Console.WriteLine("[{0}] - {1} - {2}", log.Level, log.Service, log.Message);
+
+                writer.WriteLine("[{0}] - {1} - {2}", log.Level, log.Service, log.Message);
+        }
+    }
+}

--- a/LoggerService/LogProcessor.cs
+++ b/LoggerService/LogProcessor.cs
@@ -6,19 +6,12 @@ namespace LoggerService
 {
     public static class LogProcessor
     {
-        private static StreamWriter writer;
-
-        static LogProcessor()
-        {
-            writer = new StreamWriter(AppDomain.CurrentDomain.BaseDirectory + "log.txt", true);
-        }
-
-
         public static void Process(Log log)
         {
             if (log.Level == LogLevel.CRITICAL)
                 Console.WriteLine("[{0}] - {1} - {2}", log.Level, log.Service, log.Message);
-
+                
+            using(StreamWriter writer = new StreamWriter(AppDomain.CurrentDomain.BaseDirectory + "log.txt", true))
                 writer.WriteLine("[{0}] - {1} - {2}", log.Level, log.Service, log.Message);
         }
     }

--- a/LoggerService/LoggerService.csproj
+++ b/LoggerService/LoggerService.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/LoggerService/LoggerService.csproj
+++ b/LoggerService/LoggerService.csproj
@@ -5,4 +5,9 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NewtonSoft.Json" Version="12.0.3" />
+    <PackageReference Include="RabbitMq.Client" Version="5.1.2" />
+  </ItemGroup>
+
 </Project>

--- a/LoggerService/MessageGateway.cs
+++ b/LoggerService/MessageGateway.cs
@@ -39,7 +39,6 @@ namespace LoggerService
                 CommandRouter.Route(ea.RoutingKey, message);
             };
 
-
             channel.BasicConsume(queue: queueName,
                                  autoAck: true,
                                  consumer: consumer);
@@ -47,7 +46,6 @@ namespace LoggerService
 
         internal static void PublishMessage(string queueName, string message)
         {
-
             channel.QueueDeclare(queue: queueName,
                                  durable: false,
                                  exclusive: false,

--- a/LoggerService/MessageGateway.cs
+++ b/LoggerService/MessageGateway.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Text;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace LoggerService
+{
+    public static class MessageGateway
+    {
+        private static ConnectionFactory factory;
+        private static IConnection connection;
+        private static IModel channel;
+        static MessageGateway()
+        {
+            factory = new ConnectionFactory() { HostName = "localhost" };
+            connection = factory.CreateConnection();
+            channel = connection.CreateModel();
+        }
+
+        internal static void ReceiveQueue(string exchangeName, string routingKey)
+        {
+            channel.ExchangeDeclare(exchange: exchangeName,
+                                    type: "direct");
+
+            string queueName = channel.QueueDeclare().QueueName;
+
+            channel.QueueBind(queue: queueName,
+                                  exchange: exchangeName,
+                                  routingKey: routingKey);
+
+            var consumer = new EventingBasicConsumer(channel);
+
+            consumer.Received += (model, ea) =>
+            {
+                var body = ea.Body;
+                var message = Encoding.UTF8.GetString(body);
+                Console.WriteLine(" [x] Received {0}", message);
+
+                CommandRouter.Route(ea.RoutingKey, message);
+            };
+
+
+            channel.BasicConsume(queue: queueName,
+                                 autoAck: true,
+                                 consumer: consumer);
+        }
+
+        internal static void PublishMessage(string queueName, string message)
+        {
+
+            channel.QueueDeclare(queue: queueName,
+                                 durable: false,
+                                 exclusive: false,
+                                 autoDelete: false,
+                                 arguments: null);
+
+
+            var body = Encoding.UTF8.GetBytes(message);
+
+            Console.WriteLine("Publishing to: " + queueName + " - Message: \n" + message);
+            channel.BasicPublish(
+                exchange: "",
+                routingKey: queueName,
+                basicProperties: null,
+                body: body);
+        }
+    }
+}

--- a/LoggerService/MessageGateway.cs
+++ b/LoggerService/MessageGateway.cs
@@ -12,7 +12,7 @@ namespace LoggerService
         private static IModel channel;
         static MessageGateway()
         {
-            factory = new ConnectionFactory() { HostName = "localhost" };
+            factory = new ConnectionFactory() { HostName = "rabbitmq" };
             connection = factory.CreateConnection();
             channel = connection.CreateModel();
         }

--- a/LoggerService/Model/Log.cs
+++ b/LoggerService/Model/Log.cs
@@ -10,5 +10,6 @@ namespace LoggerService.Model
     {
         public LogLevel Level { get; set; }
         public string Message { get; set; }    
+        public string Service { get; set; }    
     }
 }

--- a/LoggerService/Model/Log.cs
+++ b/LoggerService/Model/Log.cs
@@ -1,0 +1,14 @@
+namespace LoggerService.Model
+{
+    public enum LogLevel {
+        INFO,
+        WARNING,
+        CRITICAL
+    }
+
+    public class Log
+    {
+        public LogLevel Level { get; set; }
+        public string Message { get; set; }    
+    }
+}

--- a/LoggerService/Program.cs
+++ b/LoggerService/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace LoggerService
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/LoggerService/Program.cs
+++ b/LoggerService/Program.cs
@@ -9,6 +9,9 @@ namespace LoggerService
             MessageGateway.ReceiveQueue("logger","info");
             MessageGateway.ReceiveQueue("logger","warning");
             MessageGateway.ReceiveQueue("logger","critical");
+            Console.WriteLine("Running");
+            while(true)
+            {}
         }
     }
 }

--- a/LoggerService/Program.cs
+++ b/LoggerService/Program.cs
@@ -6,7 +6,9 @@ namespace LoggerService
     {
         static void Main(string[] args)
         {
-            Console.WriteLine("Hello World!");
+            MessageGateway.ReceiveQueue("logger","info");
+            MessageGateway.ReceiveQueue("logger","warning");
+            MessageGateway.ReceiveQueue("logger","critical");
         }
     }
 }


### PR DESCRIPTION
## Checklist
- [x] Implement a "**logger**" queue which would subscribe to messages which several services would publish
- [x] Receive commands in order to format the logs in different formats as needed
- [x] Have different queues for "info", "warning" and "critical"
- [x] Print to the screen the most severe logs

### PR Description
Created a new .Net Core console application.
Added functionality to allow this logger to subscribe to a exchange named **logger**. Within this exchange, it will listen in the following routing keys: _info_, _warning_, _critical_ .
Added a LogProcessor class which analyses the log in order to figure out if it should get printed to the console. All the logs that go through this class get written into a file named **log.txt** in the root of the project.

### How to test
I have created a docker image of the logger service and it is pushed to docker hub

Start by executing the following docker commands:
- `docker network create testnet`

- `docker run --rm --name rabbitmq -d --network=testnet -p 15672:15672 -p 5672:5672 rabbitmq:management`
- `docker run --rm --name loggerservice --network=testnet davi7816/testloggerservice`
(before succeeding to start the service, you should give some time to rabbitmq to start)

After all of these are started, you can test the functionality by heading to the rabbit MQ web interface at [http://localhost:15672/](http://localhost:15672/). In there head over to **Exchanges**.

> Sending a info/warning request

Publish the following message into the **logger** exchange with the **info** or **warning** routing key.
`{ "message":"This is a logged message", "service":"Random service"} `
The logger will take this information and write it into a file, you can find more information on how to access this file further down.

> Sending a info/warning request

Publish the following message into the **logger** exchange with the **critical** routing key.
`{ "message":"This is a CRITICAL logged message", "service":"Important service"} `
The logger will take this information and write it into a file, you can find more information on how to access this file further down. Furthermore, you should now see this information also printed on the screen where you executed the docker command to start the loggerservice.

> Verifying the log file

With the **logger service terminal** still executing, go ahead and open a new terminal. On the new terminal type: 
- `docker exec -it loggerservice /bin/bash`

This command should get you in a shell inside the container, on the folder _/app_ . After this step just execute the `ls` command to see the "log.txt" file listed, then use the command `cat log.txt` to view its content. The content should be the same as your published messages.

Issue reference

close #53 
close #54 
close #55 
close #56